### PR TITLE
Support for single embedded resource

### DIFF
--- a/lib/hyper_resource/objects.rb
+++ b/lib/hyper_resource/objects.rb
@@ -6,8 +6,12 @@ class HyperResource::Objects < Hash
   def init_from_hal(hal_resp)
     return unless hal_resp['_embedded']
     hal_resp['_embedded'].each do |name, collection|
-      self[name] = collection.map do |obj|
-        self.parent_resource.new_from_hal(obj)
+      if collection.is_a? Hash
+        self[name] = self.parent_resource.new_from_hal(collection)
+      else
+        self[name] = collection.map do |obj|
+          self.parent_resource.new_from_hal(obj)
+        end
       end
       unless self.respond_to?(name.to_sym)
         define_singleton_method(name.to_sym) { self[name] }

--- a/test/models/embedded_test.rb
+++ b/test/models/embedded_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+describe "Embedded Resources" do
+  it 'supports an array of embedded resources' do
+    hyper = HyperResource.new
+    hyper.response_body = {"_embedded" => {"foo" => [{"_links" => {"self" => {"href" => "http://example.com/"}}}]}}
+    hyper.init_from_response_body!
+    hyper.foo.must_be_instance_of Array
+    hyper.foo.first.href.must_equal 'http://example.com/'
+  end
+
+  it 'supports a single embedded resource' do
+    hyper = HyperResource.new
+    hyper.response_body = {"_embedded" => {"foo" => {"_links" => {"self" => {"href" => "http://example.com/"}}}}}
+    hyper.init_from_response_body!
+    hyper.foo.href.must_equal 'http://example.com/'
+  end
+end


### PR DESCRIPTION
Hi,
According to the IETF spec for HAL version 5, a single resource should be embeddable cf. http://tools.ietf.org/html/draft-kelly-json-hal-05#section-4.1.2.

Here's an update to your gem so that embedded accepts a single resource.

Cheers,
Julien & Étienne (@etiennebarrie)
