### PR TITLE
Handle array of Link Objects

### DIFF
--- a/lib/hyper_resource/links.rb
+++ b/lib/hyper_resource/links.rb
@@ -10,7 +10,13 @@ class HyperResource
     def init_from_hal(hal_resp)
       return unless hal_resp['_links']
       hal_resp['_links'].each do |rel, link_spec|
-        self[rel] = new_link_from_spec(link_spec)
+        if link_spec.is_a? Array
+          self[rel] = link_spec.map do |link|
+            new_link_from_spec(link)
+          end
+        else
+          self[rel] = new_link_from_spec(link_spec)
+        end
         create_methods_for_link_rel(rel) unless self.respond_to?(rel.to_sym)
       end
     end

--- a/test/models/links_test.rb
+++ b/test/models/links_test.rb
@@ -14,6 +14,10 @@ describe HyperResource::Links do
     it 'creates all links as HyperResource::Link or subclass' do
       @links.self.must_be_kind_of HyperResource::Link
     end
+
+    it 'handles link arrays' do
+      @links.foobars.must_be_kind_of Array
+    end
   end
 
   describe 'implicit .where' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,13 @@ HAL_BODY = {
   'attr1' => 'val1',
   'attr2' => 'val2',
   '_links' => {
-    'self' => {'href' => '/obj1/'}
+    'self' => {'href' => '/obj1/'},
+    'foobars' => [
+      { 'name' => 'foobar',
+        'templated' => true,
+        'href' => 'http://example.com/foobars/{foobar}'
+      }
+    ]
   },
   '_embedded' => {
     'obj1s' => [


### PR DESCRIPTION
Hi,

The [spec states](http://tools.ietf.org/html/draft-kelly-json-hal-05#section-4.1.1), regarding the `_links` property:

> It is an object whose property names are link relation types (as
>    defined by [RFC5988]) and values are either a Link Object or an array
>    of Link Objects.

And we needed that for CURIEs, so with @julienXX we implemented it.

Enjoy,
Étienne & Julien
