### PR TITLE
A link has an optional name

### DIFF
--- a/lib/hyper_resource/link.rb
+++ b/lib/hyper_resource/link.rb
@@ -2,6 +2,7 @@ require 'uri_template'
 
 class HyperResource::Link
   attr_accessor :base_href,
+                :name,
                 :templated,
                 :params,
                 :parent_resource
@@ -11,6 +12,7 @@ class HyperResource::Link
   def initialize(resource=nil, link_spec={})
     self.parent_resource = resource || HyperResource.new
     self.base_href = link_spec['href']
+    self.name = link_spec['name']
     self.templated = !!link_spec['templated']
     self.params    = link_spec['params'] || {}
   end
@@ -29,6 +31,7 @@ class HyperResource::Link
   def where(params)
     self.class.new(self.parent_resource,
                    'href' => self.base_href,
+                   'name' => self.name,
                    'templated' => self.templated,
                    'params' => self.params.merge(params))
   end

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 describe HyperResource::Link do
   before do
     @link = HyperResource::Link.new(nil, {'href' => '/foo{?blarg}',
+                                          'name' => 'foo',
                                           'templated' => true})
   end
 
@@ -18,6 +19,17 @@ describe HyperResource::Link do
     it 'href fills in URI template params' do
       link2 = @link.where('blarg' => 22)
       link2.href.must_equal '/foo?blarg=22'
+    end
+  end
+
+  describe '#name' do
+    it 'comes from the link spec' do
+      @link.name.must_equal 'foo'
+    end
+
+    it 'is kept when using where' do
+      link2 = @link.where('blarg' => 42)
+      link2.name.must_equal 'foo'
     end
   end
 


### PR DESCRIPTION
The spec states:

> [5.5.  name](http://tools.ietf.org/html/draft-kelly-json-hal-05#section-5.5)
> 
>   The "name" property is OPTIONAL.
> 
>   Its value MAY be used as a secondary key for selecting Link Objects
>   which share the same relation type.

It's particularly useful when having handling arrays of Link Objects (see #9)
