### PR TITLE
Not every response has a response body

### DIFF
--- a/lib/hyper_resource/modules/http.rb
+++ b/lib/hyper_resource/modules/http.rb
@@ -83,7 +83,7 @@ class HyperResource
 
       def finish_up
         begin
-          self.body = self.adapter.deserialize(self.response.body)
+          self.body = self.adapter.deserialize(self.response.body) unless self.response.body.nil?
         rescue StandardError => e
           raise HyperResource::ResponseError.new(
             "Error when deserializing response body",


### PR DESCRIPTION
Hey there,

My rails API returns a 204 No Content response in reply to certain requests, these contain no body content at all leading to an exception at this point in the code. This simple check keeps things working! Thanks for the great lib, it's been a pleasure so far.

James
