### PR TITLE
Correctly pass headers to embedded objects

### DIFF
--- a/lib/hyper_resource/adapter/hal_json.rb
+++ b/lib/hyper_resource/adapter/hal_json.rb
@@ -46,12 +46,16 @@ class HyperResource
 
           resp['_embedded'].each do |name, collection|
             if collection.is_a? Hash
-              r = rc.new(:root => rsrc.root, :namespace => rsrc.namespace)
+              r = rc.new(:root => rsrc.root,
+                         :headers => rsrc.headers,
+                         :namespace => rsrc.namespace)
               r.body = collection
               objs[name] = apply(collection, r)
             else
               objs[name] = collection.map do |obj|
-                r = rc.new(:root => rsrc.root, :namespace => rsrc.namespace)
+                r = rc.new(:root => rsrc.root,
+                           :headers => rsrc.headers,
+                           :namespace => rsrc.namespace)
                 r.body = obj
                 apply(obj, r)
               end

--- a/test/live/live_test.rb
+++ b/test/live/live_test.rb
@@ -86,6 +86,13 @@ unless !!ENV['NO_LIVE']
           del.message.must_equal "Deleted widget."
         end
 
+        it 'passes headers to sub-objects' do
+          @api.headers['X-Type'] = 'Foobar'
+          root = @api.get
+          widget = root.widgets.get.first
+          widget.headers['X-Type'].must_equal 'Foobar'
+        end
+
 
         describe "invocation styles" do
           it 'can use HyperResource with no namespace' do


### PR DESCRIPTION
The added test explains the problem case, but basically any headers set on the initial `HyperResource` object were not being passed to embedded objects. (Link objects got the headers just fine.)

I hit this when passing an OAuth 2.0 bearer token. It worked fine for link resources, but I was getting `401 Unauthorized` for any embedded resources.

The situation affects other client headers, like `Content-Type`.

``` ruby
options = { headers: { 'Authorization' => "Bearer #{access_token}" } }
api = HyperResource.new(options)
api.get.things.get
# => (A-OK)
api.get.things.first.get
# !! HyperResource::ClientError: 401 (unauthorized)
```
