### PR TITLE
made HR::Link#post (et al) work without performing an implicit get

### DIFF
--- a/lib/hyper_resource/link.rb
+++ b/lib/hyper_resource/link.rb
@@ -44,10 +44,12 @@ class HyperResource::Link
     parent_resource._hr_new_from_link(self.href)
   end
 
-  ## Returns a HyperResource representing this link, and fetches it.
-  def get
-    self.resource.get
-  end
+  ## Delegate HTTP methods to the resource.
+  def get(*args);    self.resource.get(*args)    end
+  def post(*args);   self.resource.post(*args)   end
+  def patch(*args);  self.resource.patch(*args)  end
+  def put(*args);    self.resource.put(*args)    end
+  def delete(*args); self.resource.delete(*args) end
 
   ## If we were called with a method we don't know, load this resource
   ## and pass the message along.  This achieves implicit loading.

--- a/lib/hyper_resource/modules/http.rb
+++ b/lib/hyper_resource/modules/http.rb
@@ -22,7 +22,8 @@ class HyperResource
 
       ## POSTs the given attributes to this resource's href, and returns
       ## the response resource.
-      def post(attrs)
+      def post(attrs=nil)
+        attrs || self.attributes
         self.response = faraday_connection.post do |req|
           req.body = adapter.serialize(attrs)
         end

--- a/test/live/live_test.rb
+++ b/test/live/live_test.rb
@@ -86,6 +86,12 @@ unless !!ENV['NO_LIVE']
           del.message.must_equal "Deleted widget."
         end
 
+        it 'can post without implicitly performing a get' do
+          widget = @api.post_only_widgets.post(:name => 'Cool Widget brah')
+          widget.class.to_s.must_equal 'WhateverAPI::Widget'
+          widget.name.must_equal "Cool Widget brah"
+        end
+
         it 'passes headers to sub-objects' do
           @api.headers['X-Type'] = 'Foobar'
           root = @api.get


### PR DESCRIPTION
Bugfix: calling `post` on a `HR::Link` would first perform a `get` on the link's resource.  This is bad behavior, but would only raise errors when the `get` would fail, such as when the GET method is not allowed on the URL.

This PR fixes this bug, so that `post/put/patch/delete` perform only the desired action, with no pre-`get`.
