### PR TITLE
Properly define accessor methods for nil attributes

### DIFF
--- a/lib/hyper_resource.rb
+++ b/lib/hyper_resource.rb
@@ -151,7 +151,7 @@ public
     if method[-1,1] == '='
       return attributes[method[0..-2]] = args.first if attributes[method[0..-2]]
     else
-      return attributes[method] if attributes && attributes[method]
+      return attributes[method] if attributes && attributes.has_key?(method)
       return objects[method] if objects && objects[method]
       if links && links[method]
         if args.count > 0

--- a/lib/hyper_resource/attributes.rb
+++ b/lib/hyper_resource/attributes.rb
@@ -63,7 +63,7 @@ class HyperResource
     end
 
     def []=(attr, value) # @private
-      return self[attr] if self[attr] == value
+      return self[attr] if self.has_key?(attr.to_s) && self[attr] == value
       _hr_mark_changed(attr) 
       super(attr.to_s, value)
     end
@@ -76,7 +76,7 @@ class HyperResource
 
     def method_missing(method, *args) # @private
       method = method.to_s
-      if self[method]
+      if has_key?(method)
         self[method]
       elsif method[-1,1] == '='
         self[method[0..-2]] = args.first

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require 'hyper_resource'
 HAL_BODY = {
   'attr1' => 'val1',
   'attr2' => 'val2',
+  'attr3' => nil,
   '_links' => {
     'curies' => [
       { 'name' => 'foo', 

--- a/test/unit/attributes_test.rb
+++ b/test/unit/attributes_test.rb
@@ -15,6 +15,10 @@ describe HyperResource::Attributes do
       @attrs.attr2.must_equal 'val2'
     end
 
+    it 'supports null attributes' do
+      @attrs.attr3.must_equal nil
+    end
+
     it 'leaves _links and _embedded alone' do
       assert_raises NoMethodError do
         @attrs._links


### PR DESCRIPTION
This pull request adds a test and code to handle cases where an attribute has a null value. After this change, calling `resource.attr` will return `nil`, instead of raising an exception. LMK if this is desired behavior.
