### PR TITLE
Support embedded resources that have no links

### DIFF
--- a/lib/hyper_resource.rb
+++ b/lib/hyper_resource.rb
@@ -106,7 +106,7 @@ public
   def self.new_from(args)
     link = args[:link]
     resource = args[:resource] || link.resource
-    href = args[:href] || link.href
+    href = args[:href] || link.href rescue nil
     url = args[:url] || URI.join(resource.root, href || '')
     response = args[:response]
     body = args[:body] || {}

--- a/lib/hyper_resource/adapter/hal_json.rb
+++ b/lib/hyper_resource/adapter/hal_json.rb
@@ -44,15 +44,17 @@ class HyperResource
 
           resp['_embedded'].each do |name, collection|
             if collection.is_a? Hash
+              href = collection['_links']['self']['href'] rescue nil
               objs[name] =
                 rsrc.new_from(:resource => rsrc,
                               :body => collection,
-                              :href => collection['_links']['self']['href'] )
+                              :href => href)
             else
               objs[name] = collection.map do |obj|
+                href = obj['_links']['self']['href'] rescue nil
                 rsrc.new_from(:resource => rsrc,
                               :body => obj,
-                              :href => obj['_links']['self']['href'] )
+                              :href => href)
               end
             end
           end

--- a/test/unit/embedded_test.rb
+++ b/test/unit/embedded_test.rb
@@ -27,4 +27,50 @@ describe "Embedded Resources" do
     hyper.adapter.apply(body, hyper)
     hyper.foo.href.must_equal 'http://example.com/'
   end
+
+  it 'supports an array of embedded resources with no "_links" property' do
+    hyper = TestAPI.new
+    body = { "_embedded" => {
+               "foo" => [
+                  {}
+               ]
+             }
+           }
+    hyper.adapter.apply(body, hyper)
+    hyper.foo.first.href.must_be_nil
+  end
+
+  it 'supports an embedded resource with no "_links" property' do
+    hyper = TestAPI.new
+    body = { "_embedded" => {
+               "foo" =>
+                  {}
+             }
+           }
+    hyper.adapter.apply(body, hyper)
+    hyper.foo.href.must_be_nil
+  end
+
+  it 'supports an array of embedded resources with no "self" link' do
+    hyper = TestAPI.new
+    body = { "_embedded" => {
+               "foo" => [
+                 {"_links" => {"bar" => {"href" => "http://example.com/"}}}
+               ]
+             }
+           }
+    hyper.adapter.apply(body, hyper)
+    hyper.foo.first.href.must_be_nil
+  end
+
+  it 'supports an embedded resource with no "self" link' do
+    hyper = TestAPI.new
+    body = { "_embedded" => {
+               "foo" =>
+                 {"_links" => {"bar" => {"href" => "http://example.com/"}}}
+             }
+           }
+    hyper.adapter.apply(body, hyper)
+    hyper.foo.href.must_be_nil
+  end
 end


### PR DESCRIPTION
Add support for embedded resources that contain no "self" link or no "_links" property at all, as permitted by the HAL spec. Fixes issue #29.