### PR TITLE
added Link#headers and get_response, post_response, etc.

### DIFF
--- a/lib/hyper_resource/link.rb
+++ b/lib/hyper_resource/link.rb
@@ -54,6 +54,7 @@ class HyperResource
       self.templated = !!link_spec['templated']
       self.params = link_spec['params'] || {}
       self.default_method = link_spec['method'] || 'get'
+      @headers = link_spec['headers'] || {}
     end
 
     ## Returns this link's href, applying any URI template params.
@@ -85,7 +86,28 @@ class HyperResource
                      'name' => self.name,
                      'templated' => self.templated,
                      'params' => self.params.merge(params),
-                     'method' => self.default_method)
+                     'method' => self.default_method,
+                     'headers' => @headers)
+    end
+
+    ## When called with a hash, returns a new scope with the given headers;
+    ## that is, returns a copy of itself with the given headers applied.
+    ## These headers will be merged with `resource.headers` at request time.
+    ##
+    ## When called with no arguments, returns the headers for this link.
+    def headers(*args)
+      if args.count == 0
+        @headers
+      else
+        self.class.new(self.resource,
+                       'href' => self.base_href,
+                       'name' => self.name,
+                       'templated' => self.templated,
+                       'params' => self.params,
+                       'method' => self.default_method,
+                       'headers' => @headers.merge(args[0]))
+
+      end
     end
 
     ## Unrecognized methods invoke an implicit load of the resource pointed

--- a/lib/hyper_resource/version.rb
+++ b/lib/hyper_resource/version.rb
@@ -1,5 +1,5 @@
 class HyperResource
-  VERSION = '0.9.0'
-  VERSION_DATE = '2014-05-29'
+  VERSION = '0.9.1'
+  VERSION_DATE = '2015-03-25'
 end
 

--- a/test/unit/http_test.rb
+++ b/test/unit/http_test.rb
@@ -136,5 +136,11 @@ describe HyperResource::Modules::HTTP do
       end
     end
 
+    it 'does get_response' do
+      hr = DummyAPI.new(:root => 'http://example.com/')
+      root = hr.get_response
+      root.wont_be_nil
+      root.must_be_kind_of Faraday::Response
+    end
   end
 end


### PR DESCRIPTION
This PR adds:

* `Link#headers`, for specifying headers to send when fetching a link.  These headers will be merged with `link.resource.headers`.
* `get_response`, `post_response`, `put_response`, `patch_response`, and `delete_response` for obtaining responses as `Faraday::Response` objects instead of parsing the responses into objects of `HyperResource` or one of its subclasses.