### PR TITLE
fix for empty body on 204 status code

### DIFF
--- a/lib/hyper_resource/modules/http.rb
+++ b/lib/hyper_resource/modules/http.rb
@@ -305,6 +305,7 @@ class HyperResource
       def empty_body?(body)
         return true if body.nil?
         return true if body.respond_to?(:empty?) && body.empty?
+        return true if body.class == String && body  =~ /^['"]+$/ # special case for status code with optional body, example Grape API with status 405
         false
       end
 

--- a/lib/hyper_resource/modules/http.rb
+++ b/lib/hyper_resource/modules/http.rb
@@ -262,17 +262,18 @@ class HyperResource
         adapter = self.resource.adapter || HyperResource::Adapter::HAL_JSON
 
         body = nil
-        begin
-          if response.body
-            body = adapter.deserialize(response.body)
-          end
-        rescue StandardError => e
-          if is_success
-            raise HyperResource::ResponseError.new(
-              "Error when deserializing response body",
-              :response => response,
-              :cause => e
-            )
+        unless empty_body?(response.body)
+          begin
+              body = adapter.deserialize(response.body)
+          rescue StandardError => e
+            if is_success
+              raise HyperResource::ResponseError.new(
+                        "Error when deserializing response body",
+                        :response => response,
+                        :cause => e
+                    )
+            end
+
           end
         end
 
@@ -299,6 +300,12 @@ class HyperResource
                                                  :body => body)
 
         end
+      end
+
+      def empty_body?(body)
+        return true if body.nil?
+        return true if body.respond_to?(:empty?) && body.empty?
+        false
       end
 
     end

--- a/test/unit/http_test.rb
+++ b/test/unit/http_test.rb
@@ -64,6 +64,25 @@ stub_connection = Faraday.new do |builder|
       ''
     ]}
 
+    # from Rack specs 'Content-type' => 'application/vnd.dummy.v1+hal+json'
+    stub.get('/204_with_nil_body') {[
+        204,
+        {},
+        nil
+    ]}
+    stub.get('/204_with_empty_string_body') {[
+        204,
+        {},
+        ''
+    ]}
+
+    stub.get('/204_with_empty_hash_body') {[
+        204,
+        {},
+        {}
+    ]}
+
+
     stub.get('/404') {[
       404,
       {'Content-type' => 'application/vnd.dummy.v1+hal+json;type=Error'},
@@ -113,6 +132,48 @@ describe HyperResource::Modules::HTTP do
       rescue HyperResource::ClientError => e
         e.response.wont_be_nil
       end
+    end
+
+    it 'Accepts response without a body (example status 204 with nil body)' do
+      hr = DummyAPI.new(:root => 'http://example.com/', :href => '204_with_nil_body')
+      root = hr.get
+      root.wont_be_nil
+      root.links.must_be_empty
+      root.attributes.must_be_empty
+      root.objects.must_be_empty
+      root.must_be_kind_of HyperResource
+      root.must_be_instance_of DummyAPI
+
+      root.response.status.must_equal 204
+      root.response.body.must_be_nil
+    end
+
+    it 'Accepts response without a body (example status 204 with empty string body)' do
+      hr = DummyAPI.new(:root => 'http://example.com/', :href => '204_with_empty_string_body')
+      root = hr.get
+      root.wont_be_nil
+      root.links.must_be_empty
+      root.attributes.must_be_empty
+      root.objects.must_be_empty
+      root.must_be_kind_of HyperResource
+      root.must_be_instance_of DummyAPI
+
+      root.response.status.must_equal 204
+      root.response.body.must_equal('')
+    end
+
+    it 'Accepts response without a body (example status 204 with empty hash body)' do
+      hr = DummyAPI.new(:root => 'http://example.com/', :href => '204_with_empty_hash_body')
+      root = hr.get
+      root.wont_be_nil
+      root.links.must_be_empty
+      root.attributes.must_be_empty
+      root.objects.must_be_empty
+      root.must_be_kind_of HyperResource
+      root.must_be_instance_of DummyAPI
+
+      root.response.status.must_equal 204
+      root.response.body.must_equal({})
     end
 
     it 'raises server error' do

--- a/test/unit/http_test.rb
+++ b/test/unit/http_test.rb
@@ -89,6 +89,12 @@ stub_connection = Faraday.new do |builder|
       '{"error": "Not found", "_links": {"root":{"href":"/"}}}'
     ]}
 
+    stub.get('/405_without_body') {[
+        405,
+        {'Content-type' => 'application/vnd.dummy.v1+hal+json;type=Error'},
+        '""'
+    ]}
+
     stub.get('/500') {[
       500,
       {'Content-type' => 'application/vnd.dummy.v1+hal+json;type=Error'},
@@ -174,6 +180,17 @@ describe HyperResource::Modules::HTTP do
 
       root.response.status.must_equal 204
       root.response.body.must_equal({})
+    end
+
+    it 'raises client error and accepts empty body for a status 405' do
+      hr = DummyAPI.new(:root => 'http://example.com/', :href => '405_without_body')
+      begin
+        hr.get
+        assert false # shouldn't get here
+      rescue HyperResource::ClientError => e
+        e.response.wont_be_nil
+        e.response.status.must_equal 405
+      end
     end
 
     it 'raises server error' do


### PR DESCRIPTION
According to HTTP spec,status code 204 should not have a body
The current code checks for 'response.body' to achieve this.

However Rack sends empty string as body for a 204 status code which is considered a body when using the response.body check.
As a result deserializing from Json fails. using .present? solves this issue

related rack information:
- example use in test : line 207 in https://github.com/rack/rack/blob/master/test/spec_response.rb
- code : line 63 in https://github.com/rack/rack/blob/master/lib/rack/response.rb
- code introduced in commit https://github.com/rack/rack/commit/c525c2871a0de628786233077ac3603e9fe5d8e4
- rack specifications : lines 238 till 244  in https://github.com/rack/rack/blob/master/SPEC