### PR TITLE
fix attribute_setter in case nil value & do not overwrite resource href with nil

### DIFF
--- a/lib/hyper_resource.rb
+++ b/lib/hyper_resource.rb
@@ -196,7 +196,7 @@ public
     ## Otherwise, try to match against attributes, then objects, then links.
     method = method.to_s
     if method[-1,1] == '='
-      return attributes[method[0..-2]] = args.first if attributes[method[0..-2]]
+      return attributes[method[0..-2]] = args.first if attributes && attributes.has_key?(method[0..-2])
     else
       return attributes[method] if attributes && attributes.has_key?(method.to_s)
       return objects[method] if objects && objects[method]

--- a/lib/hyper_resource/adapter/hal_json.rb
+++ b/lib/hyper_resource/adapter/hal_json.rb
@@ -31,7 +31,8 @@ class HyperResource
           apply_links(response, resource)
           apply_attributes(response, resource)
           resource.loaded = true
-          resource.href = response['_links']['self']['href'] rescue nil
+          new_href =  response['_links']['self']['href'] rescue nil
+          resource.href = new_href unless new_href.nil? && resource.href
           resource
         end
 

--- a/test/unit/hyper_resource_test.rb
+++ b/test/unit/hyper_resource_test.rb
@@ -19,6 +19,11 @@ describe HyperResource do
       @rsrc.attr1.must_equal :foo
     end
 
+    it 'uses method_missing on :attr= methods for attributes with nil value' do
+      @rsrc.attr3 = :foo
+      @rsrc.attr3.must_equal :foo
+    end
+
     it 'uses method_missing on :link methods' do
       @rsrc.self.must_be_instance_of HyperResource::Link
       @rsrc.links.self.must_be_instance_of HyperResource::Link


### PR DESCRIPTION
First case: attribute-setter
----------------------------
Imagine JSON response with an attribute set to nil --> previous code did not allow to modify this attribute in the HyperResource object due to failing method missing call

--> fixed + added test case

Second case: href already set
----------------------------
I encountered this while trying to build a new Hyperresource object from scratch  (idea is to mimick Hyperresource::MyObject.new call, populate it with Form field data & then post it to the server)

pseudo code:

my_client = HyperResource.new(root: http://whatever/api)
my_client.new_from(resource: my_client, href: 'koekoek', body: {'_data_type' => 'MyObject','koekoek' =>  nil, 'blabla' =>  nil})

This will:
1. create a new HyperResource object HyperResource::MyObject using resource & href
2. call adapter.apply to populate it with the body data

The current code overwrites the existing href with nil as no self ref is present in body
The provided solution avoids this