### PR TITLE
Fix regular expression

### DIFF
--- a/lib/hyper_resource/links.rb
+++ b/lib/hyper_resource/links.rb
@@ -30,7 +30,7 @@ class HyperResource
       end
 
       ## Underscore all non-word characters.
-      underscored_names = names.map{|n| n.gsub(/[^a-zA-Z_]/, '_')}
+      underscored_names = names.map{|n| n.gsub(/[^[:word:]]/, '_')}
       names = (names + underscored_names).uniq
 
       ## Register this link under every name we've come up with.


### PR DESCRIPTION
The amended behaviour aligns with the intent described in the comment above it.

Context:
A link named `container:27d6320f12e28b57ea7b2cbf423e647ab7f56793d7622069c9dc1d2f7a8d362b`

Before: 
underscored_name: `container___d____f__e__b__ea_b_cbf___e___ab_f_____d_______c_dc_d_f_a_d___b`

After:
underscored_name: `container_27d6320f12e28b57ea7b2cbf423e647ab7f56793d7622069c9dc1d2f7a8d362b`
